### PR TITLE
Remove internal key counter

### DIFF
--- a/internal/loop.go
+++ b/internal/loop.go
@@ -19,7 +19,6 @@ func RunEventLoop(ctx context.Context, reader *input.Reader, store *mapping.Stor
 			return
 		case evt := <-events:
 			if !evt.Ready {
-				store.ReleaseAll()
 				log.Fatal("read error")
 				return
 			}

--- a/internal/mapping/flat.go
+++ b/internal/mapping/flat.go
@@ -17,25 +17,13 @@ func (m *FlatMapping) Resolve(s *Store, evt JoystickEvent) ([]KeyMapping, []KeyM
 
 	markPressed := func(keys []KeyMapping) {
 		for _, key := range keys {
-			if k, found := s.pressedKeys[key]; found {
-				s.pressedKeys[key] = k + 1
-			} else {
-				s.pressedKeys[key] = 1
-				pressed = append(pressed, key)
-			}
+			pressed = append(pressed, key)
 		}
 	}
 
 	markReleased := func(keys []KeyMapping) {
 		for _, key := range keys {
-			if k, found := s.pressedKeys[key]; found {
-				if k == 1 {
-					delete(s.pressedKeys, key)
-					released = append(released, key)
-				} else {
-					s.pressedKeys[key] = k - 1
-				}
-			}
+			released = append(released, key)
 		}
 	}
 

--- a/internal/mapping/store.go
+++ b/internal/mapping/store.go
@@ -49,11 +49,10 @@ type Store struct {
 	ProfilePath string
 	ProductID   uint16
 	// path to active symlink
-	activePath  string
-	lastHat     map[uint8]int16
-	lastAxis    map[uint8]int8
-	pressedKeys map[KeyMapping]int
-	eventSubs   atomic.Pointer[map[*chan SSEEvent]struct{}]
+	activePath string
+	lastHat    map[uint8]int16
+	lastAxis   map[uint8]int8
+	eventSubs  atomic.Pointer[map[*chan SSEEvent]struct{}]
 }
 
 func NewStore(profilesPath string, productID uint16) *Store {
@@ -64,7 +63,6 @@ func NewStore(profilesPath string, productID uint16) *Store {
 		ProductID:   productID,
 		lastHat:     make(map[uint8]int16),
 		lastAxis:    make(map[uint8]int8),
-		pressedKeys: make(map[KeyMapping]int),
 	}
 
 	s.eventSubs.Store(&map[*chan SSEEvent]struct{}{})
@@ -386,19 +384,6 @@ func (s *Store) SetActiveProfile(name string) error {
 	})
 
 	return nil
-}
-
-func (s *Store) ReleaseAll() []KeyMapping {
-	if len(s.pressedKeys) == 0 {
-		return nil
-	}
-
-	released := make([]KeyMapping, 0, len(s.pressedKeys))
-	for k := range s.pressedKeys {
-		released = append(released, k)
-	}
-	s.pressedKeys = make(map[KeyMapping]int)
-	return released
 }
 
 func (s *Store) setActive(name string) {


### PR DESCRIPTION
Keys should no longer get stuck randomly.
Key combos now match how the Windows software behavior (shift+a on key, shift on another, holding the first and pressing the 2nd will release shift and still keep a down)